### PR TITLE
Update template classes to match FontAwesome v.4.3.0 classes.

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,23 +28,23 @@
 		<ul class="recaptcha_options">
 			<li>
 				<a href="javascript:Recaptcha.reload()">
-					<i class="icon-refresh"></i>
+					<i class="fa fa-refresh"></i>
 					<span class="captcha_hide">Get another CAPTCHA</span>
 				</a>
 			</li>
 			<li class="recaptcha_only_if_image">
 				<a href="javascript:Recaptcha.switch_type('audio')">
-					<i class="icon-volume-up"></i><span class="captcha_hide"> Get an audio CAPTCHA</span>
+					<i class="fa fa-volume-up"></i><span class="captcha_hide"> Get an audio CAPTCHA</span>
 				</a>
 			</li>
 			<li class="recaptcha_only_if_audio">
 				<a href="javascript:Recaptcha.switch_type('image')">
-					<i class="icon-picture"></i><span class="captcha_hide"> Get an image CAPTCHA</span>
+					<i class="fa fa-picture-o"></i><span class="captcha_hide"> Get an image CAPTCHA</span>
 				</a>
 			</li>
 			<li>
 				<a href="javascript:Recaptcha.showhelp()">
-					<i class="icon-question-sign"></i><span class="captcha_hide"> Help</span>
+					<i class="fa fa-question-circle"></i><span class="captcha_hide"> Help</span>
 				</a>
 			</li>
 		</ul>


### PR DESCRIPTION
The icon-\* classes seem to target FontAwesome v.3.2.1 and are no longer supported. Convert v.3.2.1 classes to their corresponding v.4.3.0 classes.
