### PR TITLE
Add title attribute to option links for screen readers and tooltips.

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,23 +27,23 @@
 
 		<ul class="recaptcha_options">
 			<li>
-				<a href="javascript:Recaptcha.reload()">
+				<a href="javascript:Recaptcha.reload()" title="Get another CAPTCHA">
 					<i class="fa fa-refresh"></i>
 					<span class="captcha_hide">Get another CAPTCHA</span>
 				</a>
 			</li>
 			<li class="recaptcha_only_if_image">
-				<a href="javascript:Recaptcha.switch_type('audio')">
+				<a href="javascript:Recaptcha.switch_type('audio')" title="Get an audio CAPTCHA">
 					<i class="fa fa-volume-up"></i><span class="captcha_hide"> Get an audio CAPTCHA</span>
 				</a>
 			</li>
 			<li class="recaptcha_only_if_audio">
-				<a href="javascript:Recaptcha.switch_type('image')">
+				<a href="javascript:Recaptcha.switch_type('image')" title="Get an image CAPTCHA">
 					<i class="fa fa-picture-o"></i><span class="captcha_hide"> Get an image CAPTCHA</span>
 				</a>
 			</li>
 			<li>
-				<a href="javascript:Recaptcha.showhelp()">
+				<a href="javascript:Recaptcha.showhelp()" title="Help">
 					<i class="fa fa-question-circle"></i><span class="captcha_hide"> Help</span>
 				</a>
 			</li>


### PR DESCRIPTION
The current widget's options are read only as "link" by screenreaders. Copying each option's span text to its anchor's title attribute allows screenreaders to read each option anchor and creates a tooltip for each icon.
